### PR TITLE
With requests 2.11, `requests.exceptions.InvalidHeader` is raised

### DIFF
--- a/qiita_v2/client_base.py
+++ b/qiita_v2/client_base.py
@@ -58,7 +58,7 @@ class QiitaClientBase():
         '''
         if self.access_token:
             self.HEADER.update(
-                {'Authorization': ' Bearer {}'.format(self.access_token)})
+                {'Authorization': 'Bearer {}'.format(self.access_token)})
         return self.HEADER
 
     def _request(self, method, url, params=None, headers=None):


### PR DESCRIPTION
Hi!

With requests 2.11, `requests.exceptions.InvalidHeader` is raised, because Authorization header contains leading space.

https://github.com/kennethreitz/requests/issues/3488
